### PR TITLE
Add Forex adapter to main

### DIFF
--- a/app/Models/Portfolio.php
+++ b/app/Models/Portfolio.php
@@ -43,4 +43,9 @@ class Portfolio extends Model
     {
         return $this->hasMany(Order::class);
     }
+
+    public function currency(): BelongsTo
+    {
+        return $this->belongsTo(Currency::class);
+    }
 }

--- a/app/Services/Forex/Adapters/ForexAdapter.php
+++ b/app/Services/Forex/Adapters/ForexAdapter.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Services\Forex\Adapters;
+
+use App\Models\Currency;
+use App\Services\Forex\ForexDataAdapter;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class ForexAdapter implements ForexDataAdapter
+{
+
+    private ?string $apiKey;
+
+    public function __construct()
+    {
+        $this->apiKey = config('app.FOREX_API_KEY.key');
+    }
+
+    public function getExchangeRate(Currency $sourceCurrency, Currency $targetCurrency): ?float
+    {
+        if ($sourceCurrency->symbol === $targetCurrency->symbol) {
+            return 1.0;
+        }
+
+        if (empty($this->apiKey)) {
+            Log::error('Fixer API Key is not set for ForexAdapter.');
+            return null;
+        }
+
+        $url = "https://api.apilayer.com/fixer/latest?symbols={$targetCurrency->symbol}&base={$sourceCurrency->symbol}";
+
+        try {
+            $response = Http::withHeaders([
+                'apikey' => $this->apiKey,
+            ])->get($url);
+
+            if ($response->successful()) {
+                $data = $response->json();
+
+                if (isset($data['rates'][$targetCurrency->symbol])) {
+                    return (float) $data['rates'][$targetCurrency->symbol];
+                } else {
+                    Log::warning("Fixer API: Rate for {$sourceCurrency->symbol} to {$targetCurrency->symbol} not found in response.", ['response' => $data]);
+                    return null;
+                }
+            } else {
+                Log::error("Fixer API Request Failed: {$response->status()}", ['response' => $response->body()]);
+                return null;
+            }
+        } catch (\Throwable $e) {
+            Log::error("Fixer API Exception: {$e->getMessage()}", ['exception' => $e]);
+            return null;
+        }
+    }
+}

--- a/app/Services/Forex/Adapters/ForexAdapter.php
+++ b/app/Services/Forex/Adapters/ForexAdapter.php
@@ -19,7 +19,7 @@ class ForexAdapter implements ForexDataAdapter
 
     public function getExchangeRate(Currency $sourceCurrency, Currency $targetCurrency): ?float
     {
-        if ($sourceCurrency->symbol === $targetCurrency->symbol) {
+        if ($sourceCurrency->id === $targetCurrency->id) {
             return 1.0;
         }
 
@@ -28,7 +28,7 @@ class ForexAdapter implements ForexDataAdapter
             return null;
         }
 
-        $url = "https://api.apilayer.com/fixer/latest?symbols={$targetCurrency->symbol}&base={$sourceCurrency->symbol}";
+        $url = "https://api.apilayer.com/fixer/latest?symbols={$targetCurrency->name}&base={$sourceCurrency->name}";
 
         try {
             $response = Http::withHeaders([
@@ -38,10 +38,10 @@ class ForexAdapter implements ForexDataAdapter
             if ($response->successful()) {
                 $data = $response->json();
 
-                if (isset($data['rates'][$targetCurrency->symbol])) {
-                    return (float) $data['rates'][$targetCurrency->symbol];
+                if (isset($data['rates'][$targetCurrency->name])) {
+                    return (float) $data['rates'][$targetCurrency->name];
                 } else {
-                    Log::warning("Fixer API: Rate for {$sourceCurrency->symbol} to {$targetCurrency->symbol} not found in response.", ['response' => $data]);
+                    Log::warning("Fixer API: Rate for {$sourceCurrency->name} to {$targetCurrency->name} not found in response.", ['response' => $data]);
                     return null;
                 }
             } else {

--- a/app/Services/Forex/Adapters/MockForexAdapter.php
+++ b/app/Services/Forex/Adapters/MockForexAdapter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Services\Forex\Adapters;
+
+use App\Models\Currency;
+use App\Services\Forex\ForexDataAdapter;
+use Illuminate\Support\Facades\Log;
+
+class MockForexAdapter implements ForexDataAdapter
+{
+    public function getExchangeRate(Currency $sourceCurrency, Currency $targetCurrency): ?float
+    {
+        Log::info("MockForexAdapter: Converting {$sourceCurrency->name} to {$targetCurrency->name}");
+
+        if ($sourceCurrency->id === $targetCurrency->id) {
+            return 1.0;
+        }
+
+        // Dummy conversion rates for common pairs
+        $rates = [
+            'USD_EUR' => 0.92,
+            'EUR_USD' => 1.08,
+            'USD_GBP' => 0.79,
+            'GBP_USD' => 1.27,
+            'EUR_GBP' => 0.85,
+            'GBP_EUR' => 1.18,
+        ];
+
+        $key1 = "{$sourceCurrency->name}_{$targetCurrency->name}";
+        $key2 = "{$targetCurrency->name}_{$sourceCurrency->name}";
+
+        if (isset($rates[$key1])) {
+            return $rates[$key1];
+        }
+
+        if (isset($rates[$key2])) {
+            return 1 / $rates[$key2]; // Invert the rate if the reverse pair exists
+        }
+
+        // Fallback to a generic rate or null if not found
+        // For a mock, a fixed rate or a small random variation could be used
+        return fake()->randomFloat(2, 0.5, 1.5);
+    }
+}

--- a/app/Services/Forex/ForexDataAdapter.php
+++ b/app/Services/Forex/ForexDataAdapter.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Services\Forex;
+
+use App\Models\Currency;
+
+interface ForexDataAdapter
+{
+    public function getExchangeRate(Currency $sourceCurrency, Currency $targetCurrency): ?float;
+}

--- a/app/Services/Forex/ForexDataService.php
+++ b/app/Services/Forex/ForexDataService.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Services\Forex;
+
+use App\Models\Currency;
+use App\Services\Forex\Adapters\ForexAdapter;
+use App\Services\Forex\Adapters\MockForexAdapter;
+
+class ForexDataService
+{
+    private ForexDataAdapter $adapter;
+
+    public function __construct(?ForexDataAdapter $adapter = null)
+    {
+        $this->adapter = $adapter ?? config('app.env') === 'testing'
+            ? new MockForexAdapter
+            : new ForexAdapter;
+    }
+
+    public function convert(Currency $sourceCurrency, Currency $targetCurrency, float $amount): float
+    {
+        if ($sourceCurrency->id === $targetCurrency->id) {
+            return $amount;
+        }
+
+        $rate = $this->adapter->getExchangeRate($sourceCurrency, $targetCurrency);
+
+        if ($rate === null) {
+            return $amount;
+        }
+
+        return $amount * $rate;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -131,6 +131,7 @@ return [
     'alphavantage_api' => [
         'key' => env('ALPHAVANTAGE_API_KEY', 'demo'),
     ],
+    
     'forex_api' => [
         'key' => env('FOREX_API_KEY', 'demo'),
     ],

--- a/config/app.php
+++ b/config/app.php
@@ -131,4 +131,7 @@ return [
     'alphavantage_api' => [
         'key' => env('ALPHAVANTAGE_API_KEY', 'demo'),
     ],
+    'forex_api' => [
+        'key' => env('FOREX_API_KEY', 'demo'),
+    ],
 ];

--- a/tests/Feature/Services/ForexDataServiceTest.php
+++ b/tests/Feature/Services/ForexDataServiceTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature\Services;
+use App\Services\Forex\Adapters\MockForexAdapter;
+use App\Services\Forex\ForexDataService;
+use App\Models\Currency;
+
+
+beforeEach(function () {
+    $this->service = new ForexDataService(
+        new MockForexAdapter
+    );
+});
+
+test('it can convert currency using mock adapter from USD to EUR', function () {
+    // Arrange
+    $usd = Currency::factory()->create(['name' => 'USD']);
+    $eur = Currency::factory()->create(['name' => 'EUR']);
+    $amount = 100;
+
+    // Act
+    $convertedAmount = $this->service->convert($usd, $eur, $amount);
+
+    // Assert
+    // From MockForexAdapter: 'USD_EUR' => 0.92
+    $this->assertEquals($amount * 0.92, $convertedAmount);
+});


### PR DESCRIPTION
## Beschrijving
Voegt een forex adapter en een mocker toe voor een externe api die de exchange rate van currencies ophaald en bij houdt zodat het mogelijk is om een stock te kopen van euro als je portfolio bestaat uit dollars


+ Add Currency to portfolio model
+ Add imp of forexdataservice to buyorderservice
+ Add ForexAdapter
+ Add MockForexAdapter
+ Add ForexDataAdapter
+ Add ForexDataService
+ Add forex_api key possibility to config
+ Add ForexDataServiceTest


## Gerelateerde Issues

## Definition of Done
Vink de onderstaande punten af om te bevestigen dat de code voldoet aan de kwaliteitseisen:

- [x] De code volgt de [Spatie guidelines](https://spatie.be/guidelines/laravel-php)
- [x] Tests zijn geschreven en slagen
- [x] De functionaliteit voldoet aan de eisen in de gekoppelde Issue
- [x] Er is geen onnodig commentaar of 'dead code' achtergebleven
- [x] Migraties en database-wijzigingen zijn getest
- [x] Bij aanpassingen aan DTO's of enums zijn alle referenties bijgewerkt `php artisan typescript:transform`
